### PR TITLE
feat(departments): Implementa a página de visão geral por departamentos

### DIFF
--- a/frontend/src/components/DepartmentsCard.tsx
+++ b/frontend/src/components/DepartmentsCard.tsx
@@ -1,0 +1,104 @@
+import type { Employee } from '../models/employee.model'
+import { Button, Dropdown, type MenuProps } from 'antd'
+import { ThreeDotsIcon } from './ui/icons'
+import clsx from 'clsx'
+
+interface DepartmentCardProps {
+  departmentName: string
+  employees: Employee[]
+  onEditEmployee: (employee: Employee) => void
+}
+
+export const DepartmentCard = ({
+  departmentName,
+  employees,
+  onEditEmployee,
+}: DepartmentCardProps) => {
+ 
+  const getMenuItems = (employee: Employee): MenuProps['items'] => [
+    {
+      key: '1',
+      label: 'Alterar Cargo/Depto',
+      onClick: () => onEditEmployee(employee),
+    },
+  ]
+
+  return (
+    <div className='bg-white shadow-md rounded-lg overflow-hidden'>
+      
+      <div className='p-4 bg-gray-200 border-b border-gray-200 flex justify-between items-center'>
+        <h3 className='text-xl font-bold text-gray-800'>{departmentName}</h3>
+        <span className='px-3 py-1 bg-indigo-100 text-indigo-800 text-sm font-semibold rounded-full'>
+          {employees.length} funcionário(s)
+        </span>
+      </div>
+
+      <div className='overflow-x-auto'>
+        <table className='min-w-full'>
+          <thead className='bg-white'>
+            <tr>
+              <th className='bg-gray-100 py-2 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
+                Nome
+              </th>
+              <th className='bg-gray-100  py-2 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
+                Cargo
+              </th>
+              <th className='bg-gray-100  py-2 px-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'>
+                Status
+              </th>
+              <th className='bg-gray-100  relative py-2 px-4'>
+                <span className='sr-only'>Ações</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody className='divide-y divide-gray-200'>
+            {employees.map((employee) => (
+              <tr
+                className={clsx(
+                  'px-2 text-sm  font-semibold hover:bg-gray-50',
+                  employee.ativo
+                    ? 'bg-white text-slate-700'
+                    : 'bg-gray-100 text-slate-300'
+                )}
+              >
+                <td className='px-4 py-3 whitespace-nowrap font-medium text-gray-900'>
+                  {employee.nome}
+                </td>
+                <td className='px-4 py-3 whitespace-nowrap text-gray-600'>
+                  {employee.cargo}
+                </td>
+                <td className='px-4 py-3 whitespace-nowrap text-gray-600'>
+                  <span
+                    className={clsx(
+                      'px-2 inline-flex text-xs leading-5 font-semibold rounded-full',
+                      employee.ativo
+                        ? 'bg-green-100 text-green-800'
+                        : 'bg-red-100 text-red-800'
+                    )}
+                  >
+                    {employee.ativo ? 'Ativo' : 'Inativo'}
+                  </span>
+                </td>
+
+                <td className='px-4 py-3 whitespace-nowrap text-right'>
+                  <Dropdown
+                    menu={{ items: getMenuItems(employee) }}
+                    trigger={['click']}
+                    placement='bottomRight'
+                  >
+                    <Button
+                      type='text'
+                      shape='circle'
+                      icon={<ThreeDotsIcon />}
+                      className='text-gray-500 hover:text-indigo-600'
+                    />
+                  </Dropdown>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/EditEmployeeForm.tsx
+++ b/frontend/src/components/EditEmployeeForm.tsx
@@ -44,11 +44,11 @@ export function EditEmployeeForm({
     initialValues: {
       id: employee._id,
       nome: employee.nome,
-      dataNascimento: employee.dataNascimento,
+      dataNascimento: employee.dataNascimento.split('T')[0],
       cpf: employee.cpf,
       rg: employee.rg,
       email: employee.email,
-      dataContratacao: employee.dataContratacao,
+      dataContratacao: employee.dataContratacao.split('T')[0],
       sexo: employee.sexo,
       cargo: employee.cargo,
       departamento: employee.departamento,

--- a/frontend/src/components/EditEmployeeModal.tsx
+++ b/frontend/src/components/EditEmployeeModal.tsx
@@ -1,0 +1,256 @@
+import { useDispatch } from 'react-redux'
+import * as yup from 'yup'
+import type { AppDispatch } from '../app/store'
+import { useState } from 'react'
+import { useFormik } from 'formik'
+import { updateEmployee } from '../features/employees/employeesSlice'
+import { ArrowLeftIcon } from './ui/icons'
+import { ToggleSwitch } from './ui/ToggleSwitch'
+import type { Employee } from '../models/employee.model'
+
+interface EditEmployeesModalProps {
+  employee: Employee
+  onCancel: () => void
+  onSuccess: () => void
+}
+
+const validationSchema = yup.object({
+  dataContratacao: yup.string().required('Data de contratação é obrigatória.'),
+  cargo: yup.string().required('Cargo é obrigatório.'),
+  departamento: yup.string().required('Departamento é obrigatório.'),
+  ativo: yup.boolean().required(),
+})
+
+export function EditEmployeeModal({
+  employee,
+  onCancel,
+  onSuccess,
+}: EditEmployeesModalProps) {
+  const dispatch = useDispatch<AppDispatch>()
+  const [isSubmiting, setIsSubmiting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      id: employee._id,
+      dataContratacao: employee.dataContratacao.split('T')[0],
+      cargo: employee.cargo,
+      departamento: employee.departamento,
+      ativo: employee.ativo,
+    },
+    validationSchema,
+
+    onSubmit: async (values) => {
+      setError(null)
+      setIsSubmiting(true)
+
+      try {
+        const { id, ...rest } = values
+        const employeeToUpdate = {
+          id,
+          data: {
+            ...rest,
+          },
+        }
+
+        await dispatch(updateEmployee(employeeToUpdate)).unwrap()
+        onSuccess()
+      } catch (err) {
+        setError(
+          'Erro ao editar dados do funcionário. Por favor, tente novamente.'
+        )
+        console.error('Erro ao editar dados do funcionário.', err)
+      } finally {
+        setIsSubmiting(false)
+      }
+    },
+  })
+
+  return (
+    <div className='fixed inset-0 bg-black bg-opacity-70 z-50 flex justify-center items-center p-4'>
+      <div className='flex flex-col flex-1 rounded-2xl bg-white shadow-sm relative overflow-hidden w-full max-w-lg max-h-[90vh]'>
+        <div className='bg-indigo-600 text-white px-4 md:px-6 py-3 rounded-t-2xl flex items-center gap-4'>
+          <button
+            onClick={onCancel}
+            className='text-white cursor-pointer'
+            disabled={isSubmiting}
+          >
+            <ArrowLeftIcon />
+          </button>
+
+          <h2 className='text-3xl font-bold text-white'>
+            Editando {employee.nome}
+          </h2>
+        </div>
+
+        <form
+          onSubmit={formik.handleSubmit}
+          className='p-4 md:p-6 space-y-4 md:space-y-6 overflow-y-auto'
+        >
+          {error && (
+            <div className='p-3 text-red-700 text-sm md:text-base'>{error}</div>
+          )}
+
+          <div className='flex flex-col md:flex-row items-start md:items-center justify-between border border-indigo-600 shadow-sm rounded-xl p-3 gap-3'>
+            <span className='text-sm md:text-base font-medium'>
+              O trabalhador está ativo ou inativo?
+            </span>
+
+            <ToggleSwitch
+              value={formik.values.ativo}
+              onChange={(value) => formik.setFieldValue('ativo', value)}
+              disabled={isSubmiting}
+            />
+          </div>
+
+          <div className='flex md:flex-row border border-indigo-700 shadow-sm rounded-xl p-3 gap-4 md:gap-6'>
+            <div className='flex flex-col gap-6 justify-between'>
+              <div className='flex flex-col'>
+                <label className='mb-1 md:mb-2 text-sm md:text-base'>
+                  Cargo
+                </label>
+                <select
+                  name='cargo'
+                  value={formik.values.cargo}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                  className={`border ${
+                    formik.touched.cargo && formik.errors.cargo
+                      ? 'border-red-500'
+                      : 'border-indigo-700'
+                  } px-3 py-2 rounded-lg text-sm md:text-base`}
+                  disabled={isSubmiting}
+                >
+                  <option value='' disabled className='text-gray-200'>
+                    Selecione um cargo
+                  </option>
+
+                  <option value='Analista de QA'>Analista de QA</option>
+                  <option value='Analista de RH'>Analista de RH</option>
+                  <option value='Desenvolvedor Backend Junior'>
+                    Desenvolvedor Backend Junior
+                  </option>
+                  <option value='Desenvolvedor Backend Pleno'>
+                    Desenvolvedor Backend Pleno
+                  </option>
+                  <option value='Desenvolvedor Backend Senior'>
+                    Desenvolvedor Backend Sênior
+                  </option>
+                  <option value='Desenvolvedor Frontend Junior'>
+                    Desenvolvedor Frontend Junior
+                  </option>
+                  <option value='Desenvolvedor Frontend Pleno'>
+                    Desenvolvedor Frontend Pleno
+                  </option>
+                  <option value='Desenvolvedor Frontend Senior'>
+                    Desenvolvedor Frontend Sênior
+                  </option>
+                  <option value='Desenvolvedor Fullstack Junior'>
+                    Desenvolvedor Fullstack Junior
+                  </option>
+                  <option value='Desenvolvedor Fullstack Pleno'>
+                    Desenvolvedor Fullstack Pleno
+                  </option>
+                  <option value='Desenvolvedor Fullstack Senior'>
+                    Desenvolvedor Fullstack Sênior
+                  </option>
+                  <option value='DevOps Junior'>DevOps Junior</option>
+                  <option value='DevOps Pleno'>DevOps Pleno</option>
+                  <option value='DevOps Senior'>DevOps Sênior</option>
+                  <option value='Estagiario'>Estagiário</option>
+                  <option value='Gerente de Projetos'>
+                    Gerente de Projetos
+                  </option>
+                  <option value='UI/UX Designer'>UI/UX Designer</option>
+                </select>
+                {formik.touched.cargo && formik.errors.cargo && (
+                  <div className='text-red-500 text-xs md:text-sm'>
+                    {formik.errors.cargo}
+                  </div>
+                )}
+              </div>
+
+              <div className='flex flex-col'>
+                <label className='mb-1 md:mb-2 text-sm md:text-base'>
+                  Departamento
+                </label>
+                <select
+                  name='departamento'
+                  value={formik.values.departamento}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                  className={`border ${
+                    formik.touched.departamento && formik.errors.departamento
+                      ? 'border-red-500'
+                      : 'border-indigo-700'
+                  } px-3 py-2 rounded-lg text-sm md:text-base`}
+                  disabled={isSubmiting}
+                >
+                  <option value='' disabled>
+                    Selecione um departamento
+                  </option>
+                  <option value='Engenharia'>Engenharia</option>
+                  <option value='Marketing'>Marketing</option>
+                  <option value='Produto'>Produto</option>
+                  <option value='RH'>RH</option>
+                </select>
+                {formik.touched.departamento && formik.errors.departamento && (
+                  <div className='text-red-500 text-xs md:text-sm'>
+                    {formik.errors.departamento}
+                  </div>
+                )}
+              </div>
+
+              <div className='flex flex-col'>
+                <label className='mb-1 md:mb-2 text-sm md:text-base'>
+                  Data de Contratação
+                </label>
+                <input
+                  type='date'
+                  placeholder='Data de Contratação'
+                  name='dataContratacao'
+                  value={formik.values.dataContratacao}
+                  onChange={formik.handleChange}
+                  onBlur={formik.handleBlur}
+                  className={`border ${
+                    formik.touched.dataContratacao &&
+                    formik.errors.dataContratacao
+                      ? 'border-red-500'
+                      : 'border-indigo-500'
+                  } px-3 py-2 rounded-lg text-sm md:text-base`}
+                  disabled={isSubmiting}
+                />
+                {formik.touched.dataContratacao &&
+                  formik.errors.dataContratacao && (
+                    <div className='text-red-500 text-xs md:text-sm'>
+                      {formik.errors.dataContratacao}
+                    </div>
+                  )}
+              </div>
+            </div>
+          </div>
+          <div className='flex justify-end gap-3 pt-4 border-t border-gray-200'>
+            <button
+              type='button'
+              onClick={onCancel}
+              disabled={isSubmiting}
+              className='px-6 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors'
+            >
+              Cancelar
+            </button>
+            <button
+              type='submit'
+              className={`px-6 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors ${
+                isSubmiting ? 'cursor-wait opacity-70' : ''
+              }`}
+              disabled={isSubmiting}
+            >
+              {isSubmiting ? 'Salvando...' : 'Salvar Alterações'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/EmployeeTableRow.tsx
+++ b/frontend/src/components/EmployeeTableRow.tsx
@@ -98,7 +98,7 @@ export const EmployeeTableRow = ({
       />
 
       <tr
-        className={`px-2 text-xs  font-semibold ${
+        className={`px-2 text-xs  font-semibold hover:bg-gray-50 ${
           employee.ativo
             ? 'bg-white text-slate-700'
             : 'bg-gray-100 text-slate-300'

--- a/frontend/src/pages/Departments.tsx
+++ b/frontend/src/pages/Departments.tsx
@@ -1,5 +1,99 @@
-import { Soon } from '../components/Soon'
+import { useEffect, useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { fetchEmployees } from '../features/employees/employeesSlice'
+import type { Employee } from '../models/employee.model'
+import type { AppDispatch, RootState } from '../app/store'
+import { DepartmentCard } from '../components/DepartmentsCard'
+import { EditEmployeeModal } from '../components/EditEmployeeModal'
 
 export default function DepartmentsPage() {
-  return <Soon />
+  const dispatch = useDispatch<AppDispatch>()
+  const {
+    data: employees,
+    status,
+    error,
+  } = useSelector((state: RootState) => state.employees)
+  const [editingEmployee, setEditingEmployee] = useState<Employee | null>(null)
+
+  useEffect(() => {
+    if (status === 'idle') {
+      dispatch(fetchEmployees())
+    }
+  }, [status, dispatch])
+
+  const departmentsData = useMemo(() => {
+    if (!employees) return []
+
+    const groupedByDept = employees.reduce((acc, employee) => {
+      const dept = employee.departamento || 'Sem Departamento'
+      if (!acc[dept]) {
+        acc[dept] = []
+      }
+      acc[dept].push(employee)
+      return acc
+    }, {} as Record<string, Employee[]>)
+
+    return Object.entries(groupedByDept)
+      .map(([departmentName, employeesInDept]) => ({
+        departmentName,
+        employees: employeesInDept,
+      }))
+      .sort((a, b) => a.departmentName.localeCompare(b.departmentName))
+  }, [employees])
+
+  if (status === 'loading') {
+    return (
+      <div className='flex h-screen w-full items-center justify-center'>
+        <p className='text-lg text-gray-600'>Carregando departamentos...</p>
+      </div>
+    )
+  }
+
+  if (status === 'failed') {
+    return (
+      <div className='flex h-screen w-full items-center justify-center bg-red-50 p-4'>
+        <p className='text-lg font-semibold text-red-600'>
+          Erro ao carregar dados: {error}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {editingEmployee && (
+        <EditEmployeeModal
+          employee={editingEmployee}
+          onCancel={() => setEditingEmployee(null)}
+          onSuccess={() => setEditingEmployee(null)}
+        />
+      )}
+
+      <div className='flex-1 bg-gray-100 p-6 md:p-8 min-h-screen'>
+        <div className='max-w-7xl mx-auto space-y-8'>
+          <div>
+            <div className='bg-indigo-600 shadow-sm px-6 py-4 rounded-t-2xl'>
+              <h2 className='text-3xl font-bold text-white'>
+                Visão Geral por Departamentos
+              </h2>
+            </div>
+            <p className='text-gray-500 mt-1'>
+              Veja a distribuição dos seus colaboradores na empresa.
+            </p>
+          </div>
+
+          <div className='grid grid-cols-1 xl:grid-cols-2 gap-8'>
+            {departmentsData.map(({ departmentName, employees }) => (
+              <DepartmentCard
+                key={departmentName}
+                departmentName={departmentName}
+                employees={employees}
+                onEditEmployee={(employee) => setEditingEmployee(employee)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
 }


### PR DESCRIPTION
### Descrição

Este PR introduz uma nova página estratégica para a aplicação: a **Visão Geral por Departamentos**. O objetivo desta página não é gerenciar os departamentos em si, mas sim oferecer uma nova perspectiva sobre a estrutura da equipe, agrupando os colaboradores em seus respectivos departamentos.

As principais funcionalidades entregues são:

1.  **Visualização Agrupada:** Apresenta os funcionários em "cards" dedicados a cada departamento, exibindo o nome do departamento, o número total de membros e uma lista detalhada de quem pertence a ele.
2.  **Acesso Rápido à Edição:** Permite que o administrador edite os dados de um funcionário (como cargo e departamento) diretamente a partir desta nova visão, promovendo agilidade na gestão.
3.  **Refatoração de Componentes:** Melhora a arquitetura do frontend ao refatorar o modal de edição para um componente mais robusto e reutilizável.

---

### Como isso foi feito?

**1. Página de Departamentos (`Departments.tsx`):**
-   A página busca os dados do `employeesSlice` existente, **não necessitando de novas chamadas à API ou alterações no backend**.
-   A lógica principal reside em um hook `useMemo`, que processa a lista linear de funcionários e a transforma em uma estrutura de dados agrupada por departamento dinamicamente no frontend.
-   Ela gerencia o estado de exibição do modal de edição através do `useState`, passando os dados do funcionário selecionado para o componente de formulário.

**2. Card de Departamento (`DepartmentCard.tsx`):**
-   Um novo componente reutilizável que recebe o nome de um departamento e a lista de seus funcionários como props.
-   Renderiza um cabeçalho com estatísticas (ex: "5 funcionários") e uma tabela interna compacta com os membros daquele departamento.
-   Cada linha da tabela interna possui um menu de ações (`Dropdown` do Ant Design) que dispara a função de edição na página pai.

**3. Refatoração do Modal de Edição (`EditEmployeeModal.tsx`):**
-   O componente foi significativamente refatorado para se tornar **totalmente encapsulado e autônomo**.
-   Agora ele controla sua própria visibilidade através de uma prop `isOpen`, e sua lógica de container (fundo escuro, posicionamento) foi movida para dentro do próprio componente.
-   Isso simplificou drasticamente o código na `DepartmentsPage`, que agora apenas decide **quando** o modal deve ser exibido, sem se preocupar com **como** ele é renderizado.

---

### Como testar?

1.  Faça o checkout desta branch, rode `npm install` e `npm run dev`.
2.  Acesse a nova rota da aplicação (provavelmente `/departamentos`).

3.  **Teste de Visualização:**
    -   Confirme que a página carrega com o título "Visão Geral por Departamentos".
    -   Verifique se um "card" é renderizado para cada departamento existente nos dados (Engenharia, RH, etc.).
    -   Em cada card, confirme se a contagem de funcionários no cabeçalho está correta.
    -   Verifique se a tabela dentro de cada card lista apenas os funcionários que pertencem àquele departamento.

4.  **Teste da Funcionalidade de Edição:**
    -   Escolha um funcionário em qualquer card de departamento. Clique no menu de ações (`...`) e selecione "Alterar Cargo/Depto".
    -   Confirme que o modal de edição abre, pré-preenchido com os dados corretos daquele funcionário.
    -   Altere o **departamento** do funcionário para um departamento diferente e salve.
    -   Verifique se o modal fecha e se o funcionário **desaparece do card original e aparece no novo card de departamento**, tudo isso sem recarregar a página.
    -   Edite o **cargo** de um funcionário e confirme que a informação é atualizada na tabela dentro do card.